### PR TITLE
Fix parsing of mock SHM header

### DIFF
--- a/main/obt_simit_interface/MockShmData.h
+++ b/main/obt_simit_interface/MockShmData.h
@@ -13,14 +13,16 @@ inline std::vector<uint8_t> createMockShmData() {
 
     uint32_t total_size = 1024;
     uint32_t header_size = 50;
-    uint32_t version = 0;
+    uint16_t version = 0;
     uint32_t sampling_time = 100;
+    uint16_t cycle_counter = 0;
     uint8_t mutex_len = 5;
 
     append(total_size);
     append(header_size);
     append(version);
     append(sampling_time);
+    append(cycle_counter);
     append(mutex_len);
 
     const char* mutex_name = "Mutex";
@@ -58,4 +60,3 @@ inline std::vector<uint8_t> createMockShmData() {
 
     return shm;
 }
-#pragma once

--- a/main/obt_simit_interface/ShmHeaderParser.h
+++ b/main/obt_simit_interface/ShmHeaderParser.h
@@ -131,4 +131,3 @@ private:
         std::cout << "Sampling time: " << header_->sampling_time_ms << " ms\n";
     }
 };
-#pragma once


### PR DESCRIPTION
## Summary
- correct `createMockShmData` layout to match `ShmHeaderFixed`
- remove stray `#pragma once` directives

## Testing
- `g++ main/obt_simit_interface/obt_simit_interface.cpp -std=c++17 -o sim_test`
- `./sim_test`


------
https://chatgpt.com/codex/tasks/task_e_686588399930832da5d2aa964bb65a1e