### PR TITLE
Clean up buffer size print in SIMIT interface

### DIFF
--- a/main/obt_simit_interface/obt_simit_interface.cpp
+++ b/main/obt_simit_interface/obt_simit_interface.cpp
@@ -10,11 +10,6 @@ int main() {
     if (!shm_data.data()) {
         std::cout << "Error: SHM data pointer is null!\n";
     }
-    std::cout << "Mock SHM buffer size: " << shm_data.size() << "\n";
-    
-    if (shm_data.data() == nullptr) {
-        std::cout << "Error: shm_data.data() is nullptr!\n";
-    }
     
     std::cout << "Mock SHM buffer address: " << static_cast<void*>(shm_data.data()) << "\n";
     std::cout << "sizeof(ShmHeaderFixed): " << sizeof(ShmHeaderFixed) << "\n";


### PR DESCRIPTION
## Summary
- de-dupe null pointer check in obt_simit_interface
- print SHM buffer size once

## Testing
- `g++ main/obt_simit_interface/obt_simit_interface.cpp -o /tmp/obt_simit_interface`
- `/tmp/obt_simit_interface | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68658b64d224832d8a8c162d1cada2f7