### PR TITLE
Print cycle counter

### DIFF
--- a/main/obt_simit_interface/ShmHeaderParser.h
+++ b/main/obt_simit_interface/ShmHeaderParser.h
@@ -129,6 +129,7 @@ private:
         std::cout << "Header size: " << header_->header_size << "\n";
         std::cout << "Version: " << header_->version << "\n";
         std::cout << "Sampling time: " << header_->sampling_time_ms << " ms\n";
+        std::cout << "Cycle counter: " << header_->cycleCounter << "\n";
     }
 };
 #pragma once


### PR DESCRIPTION
## Summary
- show `cycleCounter` when printing SHM header info

## Testing
- `g++ main/obt_simit_interface/obt_simit_interface.cpp -std=c++17 -o obt_simit_interface`
- `./obt_simit_interface | head`

------
https://chatgpt.com/codex/tasks/task_e_68658b641510832d923234d457bd2f2c